### PR TITLE
Initialize Fabric mod skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # mcserversideai
+
 minecraft serverside fabric 1.21.4 mod where you can chat with the Gemini API, and it can call a command running tool to run commands.
+
+## Roadmap
+
+1. **Establish the Development Environment**
+   - Install Java (JDK 17+ is recommended for Fabric).
+   - Set up a new Fabric mod project targeting **Minecraft 1.21.4**. You can use the [Fabric example mod](https://github.com/FabricMC/fabric-example-mod) as a template.
+
+2. **Initialize the Repository**
+   - Create the standard Fabric project layout (`src/main/java`, `resources`, `build.gradle`, etc.).
+   - Add a basic mod entry point class with `@ModInitializer` to bootstrap server-side logic.
+
+3. **Integrate the Gemini API**
+   - Decide how the server will communicate with the Gemini API (likely via HTTP requests).
+   - Provide configuration options for the API key and settings.
+
+4. **Implement Chat Handling**
+   - Listen for chat events or commands like `/gemini <message>`.
+   - Forward text to Gemini and display its response to the player.
+
+5. **Create the Command Execution Tool**
+   - Parse Gemini responses for commands and execute them through the server's command manager.
+   - Sanitize and validate any commands before execution.
+
+6. **Permissions and Safety**
+   - Restrict who can interact with the mod and run commands.
+   - Add timeouts or rate limits to prevent abuse.
+
+7. **Packaging and Distribution**
+   - Test the mod locally.
+   - Package the compiled JAR and provide usage documentation.
+
+This roadmap provides a starting point for turning this repository into the described mod.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'fabric-loom' version '1.5.5'
+}
+
+group = 'com.example'
+version = '1.0.0'
+
+repositories {
+    mavenCentral()
+    maven { url 'https://maven.fabricmc.net/' }
+}
+
+dependencies {
+    minecraft "com.mojang:minecraft:1.21.4"
+    mappings "net.fabricmc:yarn:1.21.4+build.1"
+    modImplementation "net.fabricmc:fabric-loader:0.15.0"
+}
+
+loom {
+    splitEnvironmentSourceSets()
+}
+
+sourceCompatibility = JavaVersion.VERSION_17
+
+tasks.withType(JavaCompile).configureEach {
+    it.options.encoding = 'UTF-8'
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2G
+mod_version=1.0.0
+minecraft_version=1.21.4

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,9 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        maven { url 'https://maven.fabricmc.net/' }
+        mavenCentral()
+    }
+}
+
+rootProject.name = 'mcserversideai'

--- a/src/main/java/com/example/mcserversideai/Mcserversideai.java
+++ b/src/main/java/com/example/mcserversideai/Mcserversideai.java
@@ -1,0 +1,15 @@
+package com.example.mcserversideai;
+
+import net.fabricmc.api.ModInitializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Mcserversideai implements ModInitializer {
+    public static final String MOD_ID = "mcserversideai";
+    public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
+
+    @Override
+    public void onInitialize() {
+        LOGGER.info("Mcserversideai mod initialized!");
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "id": "mcserversideai",
+  "version": "1.0.0",
+  "name": "mcserversideai",
+  "description": "Minecraft serverside Fabric mod integrating Gemini API",
+  "authors": ["mcserversideai dev"],
+  "contact": {},
+  "license": "MIT",
+  "environment": "server",
+  "entrypoints": {
+    "main": ["com.example.mcserversideai.Mcserversideai"]
+  },
+  "depends": {
+    "fabricloader": ">=0.15.0",
+    "fabric": "*",
+    "minecraft": "1.21.4"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Fabric mod project structure
- add mod entry point
- include `fabric.mod.json` and basic Gradle build files

## Testing
- `gradle wrapper --gradle-version 8.4` *(fails: `Failed to setup Minecraft, java.lang.UnsupportedOperationException`)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fb1f16fb48322ab8957bf9649e6a4